### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -43,7 +43,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     - name: Log in to the Container registry
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
@@ -81,7 +81,7 @@ jobs:
         docker push ${{ steps.build_config_image.outputs.config_image }}
 
     - name: Run Antithesis Tests
-      uses: antithesishq/antithesis-trigger-action@main
+      uses: antithesishq/antithesis-trigger-action@b7d0c9d1d9316bd4de73a44144c56636ea3a64ba # main
       with:
         notebook_name: ethereum
         tenant: ethereum


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.