### PR TITLE
chore(deps): enable automatic updates for GitHub Actions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+   - package-ecosystem: github-actions
+     directory: /
+     schedule:
+        interval: monthly
+     groups:
+        actions:
+           patterns:
+              - '*'

--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -43,7 +43,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Log in to the Container registry
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
@@ -81,7 +81,7 @@ jobs:
         docker push ${{ steps.build_config_image.outputs.config_image }}
 
     - name: Run Antithesis Tests
-      uses: antithesishq/antithesis-trigger-action@b7d0c9d1d9316bd4de73a44144c56636ea3a64ba # main
+      uses: antithesishq/antithesis-trigger-action@b7d0c9d1d9316bd4de73a44144c56636ea3a64ba # v0.8
       with:
         notebook_name: ethereum
         tenant: ethereum


### PR DESCRIPTION

### 💚 Dependabot automatic updates
This PR enables automatic updates for GitHub Actions via [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).

Dependabot will periodically check for new versions of the actions and create a PR to update the version used in the repository.

This should help keeping your GitHub Actions up to date with the latest versions of the actions.

#### 🔍 How was this detected and generated?
This PR was generated using [ethpandaops/github-actions-checker](https://github.com/ethpandaops/github-actions-checker).
